### PR TITLE
[✨ Feat] 7주차-API 응답 통일 & 에러 핸들러

### DIFF
--- a/src/main/java/com/example/umc9th/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/umc9th/global/apiPayload/ApiResponse.java
@@ -11,11 +11,11 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"}) // 키의 이름과 순서 보장
 @Schema(description = "공통 응답 포맷")
 public class ApiResponse<T> {
 
-    @JsonProperty("isSuccess")
+    @JsonProperty("isSuccess") // JSON 키를 항상 isSuccess로 유지
     @Schema(description = "성공 여부", example = "true")
     private final Boolean isSuccess;
 
@@ -25,7 +25,7 @@ public class ApiResponse<T> {
     @Schema(description = "상태 메시지", example = "성공입니다.")
     private final String message;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL) // result가 없을 때 필드를 아예 생략
     @Schema(description = "결과 데이터")
     private T result;
 

--- a/src/main/java/com/example/umc9th/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/umc9th/global/apiPayload/exception/ExceptionAdvice.java
@@ -4,6 +4,7 @@ package com.example.umc9th.global.apiPayload.exception;
 import com.example.umc9th.global.apiPayload.ApiResponse;
 import com.example.umc9th.global.apiPayload.code.ErrorReasonDTO;
 import com.example.umc9th.global.apiPayload.code.status.ErrorStatus;
+import com.example.umc9th.global.notifier.DiscordNotifier;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,8 @@ import java.util.Optional;
 @RestControllerAdvice(annotations = {RestController.class}) // 전역 예외 처리기임을 선언하고, @RestController가 붙은 클래스들만 대상으로
 // ResponseEntityExceptionHandler: Spring MVC의 기본 예외 처리
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    private final DiscordNotifier discordNotifier;
 
     /**
      * @Validated 어노테이션으로 인한 유효성 검사 실패 시 (주로 @RequestParam, @PathVariable) 이 핸들러가 호출
@@ -73,6 +76,12 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         // 발생한 예외의 전체 스택 트레이스(호출 경로)를 서버 로그에 출력 (디버깅 용도)
         e.printStackTrace();
+
+        // 요청 URI 추출
+        String uri = request.getDescription(false).replace("uri=", "");
+
+        // Discord 알림 전송
+        discordNotifier.sendErrorNotification(e, uri);
 
         // _INTERNAL_SERVER_ERROR (HTTP 500) 상태를 기반으로 표준 응답생성
         return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());

--- a/src/main/java/com/example/umc9th/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/umc9th/global/apiPayload/exception/ExceptionAdvice.java
@@ -26,11 +26,16 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @Slf4j
-@RestControllerAdvice(annotations = {RestController.class})
+@RestControllerAdvice(annotations = {RestController.class}) // 전역 예외 처리기임을 선언하고, @RestController가 붙은 클래스들만 대상으로
+// ResponseEntityExceptionHandler: Spring MVC의 기본 예외 처리
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
+    /**
+     * @Validated 어노테이션으로 인한 유효성 검사 실패 시 (주로 @RequestParam, @PathVariable) 이 핸들러가 호출
+     */
     @ExceptionHandler
     public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        // 여러 에러 메세지 중 첫번째 메세지만
         String errorMessage = e.getConstraintViolations().stream()
                 .map(constraintViolation -> constraintViolation.getMessage())
                 .findFirst()
@@ -39,62 +44,99 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
     }
 
+    /**
+     * @Valid 어노테이션으로 인한 유효성 검사 실패 시 (주로 @RequestBody DTO) 이 핸들러가 호출
+     * Spring의 기본 핸들러를 오버라이드
+     */
     @Override
     public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
+        // 유효성 검사에 실패한 필드와 에러 메시지를 저장할 Map
         Map<String, String> errors = new LinkedHashMap<>();
-
+        // 예외 객체(e)의 BindingResult에서 모든 필드 에러(FieldErrors)를 가져와 스트림으로 처리
         e.getBindingResult().getFieldErrors().stream()
                 .forEach(fieldError -> {
-                    String fieldName = fieldError.getField();
-                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    String fieldName = fieldError.getField(); // 에러가 발생한 필드 이름
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse(""); // 에러에 설정된 기본 메세지
+                    // Map에 필드 이름(key)과 에러 메시지(value)를 저장
+                    // 만약 이미 동일한 필드 이름(key)이 존재하면, 기존 메시지 뒤에 새 메시지
                     errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
                 });
 
         return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
     }
 
+    /**
+     * 위에서 명시적으로 처리되지 않은 모든 Exception을 처리하는 핸들러
+     */
     @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        // 발생한 예외의 전체 스택 트레이스(호출 경로)를 서버 로그에 출력 (디버깅 용도)
         e.printStackTrace();
 
+        // _INTERNAL_SERVER_ERROR (HTTP 500) 상태를 기반으로 표준 응답생성
         return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
     }
 
+
+    /**
+     * 개발자가 직접 정의한 'GeneralException' (커스텀 비즈니스 예외)을 처리하는 핸들러
+     */
     @ExceptionHandler(value = GeneralException.class)
     public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        // 예외 객체(generalException)로부터 미리 정의된 에러 이유(ErrorReasonDTO)를 가져옴
         ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+
+        // 가져온 에러 이유를 기반으로 표준 응답(ResponseEntity)을 생성하여 반환
         return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
     }
 
+    /**
+     * [Helper 메소드] GeneralException 처리를 위한 표준 응답 ResponseEntity를 생성
+     */
     private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
                                                            HttpHeaders headers, HttpServletRequest request) {
 
+        // ApiResponse의 정적 메소드 onFailure를 호출하여, 표준 실패 응답 본문(body)을 생성
+        // data 필드는 null로 설정
         ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
 //        e.printStackTrace();
 
+        // HttpServletRequest를 WebRequest로 래핑(Wrapping)
         WebRequest webRequest = new ServletWebRequest(request);
+
+        // 부모 클래스(ResponseEntityExceptionHandler)의 handleExceptionInternal 메소드를 호출
         return super.handleExceptionInternal(
-                e,
-                body,
-                headers,
-                reason.getHttpStatus(),
-                webRequest
+                e, // 원본 예외 객체
+                body, // 표준 응답 본문 (ApiResponse)
+                headers, // HTTP 헤더 (이 경우 null이 전달됨)
+                reason.getHttpStatus(), // ErrorReasonDTO에 정의된 HTTP 상태 코드
+                webRequest // 래핑된 WebRequest 객체
         );
     }
 
+    /**
+     * [Helper 메소드] 예측하지 못한 'Exception' 처리를 위한 표준 응답 ResponseEntity를 생성
+     */
     private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
                                                                 HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        // ApiResponse.onFailure를 호출하여 표준 실패 응답 본문(body)을 생성
+        // data 필드에 어떤 에러인지 식별 가능한 메시지(errorPoint)를 담음
         ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+
+        // 부모 클래스의 handleExceptionInternal 메소드를 호출
         return super.handleExceptionInternal(
-                e,
-                body,
-                headers,
-                status,
-                request
+                e, // 원본 예외 객체
+                body, // 표준 응답 본문 (ApiResponse)
+                headers, // HTTP 헤더
+                status, // HTTP 상태 코드 (e.g., 500)
+                request // WebRequest 객체
         );
     }
 
+    /**
+     * [Helper 메소드] MethodArgumentNotValidException (DTO 유효성 검사) 처리를 위한 표준 응답 ResponseEntity를 생성합니다.
+     */
     private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
                                                                WebRequest request, Map<String, String> errorArgs) {
         ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
@@ -107,6 +149,9 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         );
     }
 
+    /**
+     * [Helper 메소드] ConstraintViolationException (파라미터 유효성 검사) 처리를 위한 표준 응답 ResponseEntity를 생성합니다.
+     */
     private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
                                                                      HttpHeaders headers, WebRequest request) {
         ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);

--- a/src/main/java/com/example/umc9th/global/notifier/DiscordNotifier.java
+++ b/src/main/java/com/example/umc9th/global/notifier/DiscordNotifier.java
@@ -1,0 +1,87 @@
+package com.example.umc9th.global.notifier;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+/**
+ * 서버에서 발생한 예외(500 Internal Server Error)를 Discord Webhook으로 전송하는 역할
+ * ExceptionAdvice에서 예외 발생 시 이 클래스를 호출하여 메시지를 전송
+ */
+@Slf4j
+@Component
+public class DiscordNotifier {
+
+    @Value("${webhook.discord-url:}")
+    private String discordWebhookUrl; // Discord로 메시지를 보낼 Webhook 주소
+
+    @Value("${spring.profiles.active:local}")
+    private String activeProfile; // 현재 실행 중인 환경
+
+    // REST API 요청을 보내기 위한 Spring의 HTTP 클라이언트 객체
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    /**
+     * 예외 발생 시 호출되는 핵심 메서드
+     * @param e 발생한 예외 객체
+     * @param requestUri 에러가 발생한 요청 URI
+     */
+    public void sendErrorNotification(Exception e, String requestUri) {
+        // 1. 환경 분기 - 로컬 환경에서는 알림 보내지 않음
+        if (!"prod".equalsIgnoreCase(activeProfile) && !"dev".equalsIgnoreCase(activeProfile)) {
+            log.info("[DISCORD-NOTIFY] Skip sending message in {} environment", activeProfile);
+            return;
+        }
+
+        // 2. 에러 발생 시각을 문자열로 포맷팅
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+        // 3. Discord 메시지 포맷 생성
+        String content = String.format(
+                "🚨 **서버 에러 발생** 🚨\n" +
+                        "```%s```\n" +
+                        "📅 발생 시간: %s\n" +
+                        "🌍 환경: %s\n" +
+                        "📡 요청 URL: %s\n" +
+                        "🧩 예외: %s\n" +
+                        "💬 메시지: %s",
+                e.getClass().getSimpleName(), // 간단한 클래스명
+                timestamp, // 발생 시간
+                activeProfile, // 현재 환경
+                requestUri, // 요청 URL
+                e.getClass().getName(), // 예외 클래스 전체 이름
+                e.getMessage() // 예외 메시지 (개발자에게 디버깅 정보 제공)
+        );
+
+        try {
+            // 4. HTTP 요청 헤더 생성
+            // Content-Type: application/json 설정 (Discord Webhook은 JSON 형식으로만 메시지를 받음)
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            // 5. Discord Webhook으로 전송할 JSON 본문 생성
+            // Discord Webhook은 {"content": "메시지내용"} 형태의 JSON만 인식함
+            Map<String, String> payload = Map.of("content", content);
+
+            // 6. HttpEntity로 헤더와 본문을 묶어서 하나의 HTTP 요청 객체로 만듦
+            HttpEntity<Map<String, String>> entity = new HttpEntity<>(payload, headers);
+
+            // 7. POST 요청 전송 - Discord Webhook에 메시지를 전송함
+            // restTemplate.postForEntity(요청URL, 요청본문, 응답타입)
+            restTemplate.postForEntity(discordWebhookUrl, entity, String.class);
+
+            log.info("[DISCORD-NOTIFY] Error sent to Discord channel successfully.");
+
+        } catch (Exception ex) {
+            log.error("[DISCORD-NOTIFY] Failed to send message to Discord: {}", ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/umc9th/global/notifier/TestController.java
+++ b/src/main/java/com/example/umc9th/global/notifier/TestController.java
@@ -1,0 +1,27 @@
+package com.example.umc9th.global.notifier;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 서버의 500 Internal Server Error 발생 시
+ * ExceptionAdvice가 정상적으로 에러를 잡고
+ * DiscordNotifier를 통해 알림이 전송되는지 확인하기 위한 테스트용 컨트롤러
+ */
+@RestController
+@RequestMapping("/test")
+public class TestController {
+
+    /**
+     * 강제로 500 Internal Server Error를 발생시키는 테스트용 API 엔드포인트
+     * GET /test/error 요청 시 RuntimeException을 던져 서버 예외 상황을 의도적으로 유발
+     * → ExceptionAdvice의 @ExceptionHandler(Exception.class)가 이 예외를 잡아 처리함
+     * → DiscordNotifier가 자동으로 Webhook POST 요청을 전송
+     */
+    @GetMapping("/error")
+    public String triggerError() {
+        // 강제로 500 에러 발생시키기
+        throw new RuntimeException("강제 500 에러 발생 테스트");
+    }
+}


### PR DESCRIPTION
<!-- PR 제목은 "Week#/이름" 으로 작성 -->
<!-- ex) Week3/Jin -->

## #️⃣ 연관된 이슈
> - #7 

## 📝 미션 번호
<!-- 주차와 미션 번호를 넣어주세요 -->
<!-- 미션 여러 개 나열 가능 -->
7주차 Misson

## 📋 구현 사항
<!-- 구현한 내용을 bullet point로 작성해주세요 -->
<details>
  <summary>API 응답통일</summary>
<img width="334" height="342" alt="image" src="https://github.com/user-attachments/assets/827f31b4-7f43-44df-b2fa-a1d6e9ec9471" />

global 패키지 안에 apiPayload 패키지를 만들어 응답 통일 코드를 작성하였다.
status 패키지를 만들어 에러나 성공 메세지에 대한 enum을 둔 파일을 넣어 분리하였다.

<img width="400" height="568" alt="image" src="https://github.com/user-attachments/assets/9ec71c84-476e-4e9f-b2a0-408bd7438049" />

ReasonDTO와 ErrorReasonDTO는 각각 성공와 실패시 응답에 대한 dto이다. 컨트롤러나 예외 처리에서 일관된 응답을 위한 dto이다.
JavaBeans 규칙상 boolean 필드는 기본 게터가 `isXxx()`가 된다. 
Lombok이 이렇게 게터를 만들면 Jackson은 `is`를 접두사로 보고 제거해, 결과적으로 속성 이름을 `success`로 해석하게 된다. (필드명이 `isSuccess`여도 JSON 키가 `success`로 나갈 수 있음)
이를 방지하기 위해 게터 명을`getIsSuccess()`로 두거나
`@JsonProperty("isSuccess")`로 키 이름을 고정하는 방식을 쓴다. 나는 여기서 게터명을 설정해주었다.

<img width="400" height="310" alt="image" src="https://github.com/user-attachments/assets/8fa643c8-820b-4dd6-a3e9-16e1d1c9a52c" />

BaseCode는 성공 응답 코드를 표준화할대 구현하도록 하는 인터페이스 이다.
getReason과 getReasonHttpStatus 두 메서드 모두 ReasonDTO를 반환하지만 http상태를 포함하냐 안하냐에 따라 구분한 것이다.

<img width="400" height="828" alt="image" src="https://github.com/user-attachments/assets/ac0917be-3cf6-4742-836d-058bf21cebb6" />

해당 메서드들은 status 코드들에 오버라이딩 하여 구현
이제 이 값들을 가지고 ApiResponse를 채우고 공통 응답을 보내게 된다.
예외가 발생하였을 때 successstatus나 errorstatus가 주는 DTO를 꺼내 ApiResponse로 만들어 반환하게 된더ㅏ.
- `@JsonProperty("isSuccess")`와 `@JsonPropertyOrder`로 **키 이름과 순서**를 보장
- `@JsonInclude(NON_NULL)`로 `result`가 없을 때 **필드를 아예 생략**해 응답을 간결하게 만듦
</details>

<details>
  <summary>ExceptionAdvice</summary>

### `validation()`

<img width="400" height="618" alt="image" src="https://github.com/user-attachments/assets/b3cdad85-bd86-4943-bd84-5f29ccc42d0d" />

`ConstraintViolationException` 는 제약 조건 위반 예외로, `@Valid` 가 아닌 메서드 파라미터 수준(@RequestParam, @PathVariable, @RequestHeader등)에서 검증 실패시 발생한다. 

즉, 컨트롤러 메서드의 파라미터나 Pathvariable에 @Notnull, @Size 등을 붙혔을 때, 유효하지 않은 값이 들어오면 이 예외가 던져진다.

### `handleMethodArgumentNotValid()`

```java
/**
     * @Valid 어노테이션으로 인한 유효성 검사 실패 시 (주로 @RequestBody DTO) 이 핸들러가 호출
     * Spring의 기본 핸들러를 오버라이드
     */
    @Override
    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {

        // 유효성 검사에 실패한 필드와 에러 메시지를 저장할 Map
        Map<String, String> errors = new LinkedHashMap<>();
        // 예외 객체(e)의 BindingResult에서 모든 필드 에러(FieldErrors)를 가져와 스트림으로 처리
        e.getBindingResult().getFieldErrors().stream()
                .forEach(fieldError -> {
                    String fieldName = fieldError.getField(); // 에러가 발생한 필드 이름
                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse(""); // 에러에 설정된 기본 메세지
                    // Map에 필드 이름(key)과 에러 메시지(value)를 저장
                    // 만약 이미 동일한 필드 이름(key)이 존재하면, 기존 메시지 뒤에 새 메시지
                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
                });

        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
    }
```

이 메서드는 `MethodArgumentNotValidException` 를 처리하는 메서드 이다. 
`MethodArgumentNotValidException` 는 **`@Valid` 또는 `@Validated`** 가 붙은 **RequestBody 필드 검증**에서 실패할 때 발생하는 예외이다. 
→ 결과적으로 `ApiResponse.onFailure("_BAD_REQUEST", errors, null)`같은 형식으로 통일된 에러 응답 포맷을 생성

### ResponseEntityExceptionHandler 메서드

<img width="400" height="791" alt="image" src="https://github.com/user-attachments/assets/e3f0f0fb-753f-4f0c-a03a-68896d8f2c0c" />

ResponseEntityExceptionHandler는 스프링이 제공하는 예외 처리용 추상 클래스이다. 사진 말고도 엄청 많은 메서드가 이씀..
`@ControllerAdvice`에서 상속하면 스프링 MVC가 발생시키는 표준 예외들을 미리 정의된 메서드로 잡아서 처리할 수 있게한다.

- `handleHttpRequestMethodNotSupported` : 지원하지 않는 HTTP 메서드(ex) put 요청 불가)
- `handleHttpMediaTypeNotSupported` : 지원하지 않는 Content-Type
- `handleMissingServletRequestParameter` : 필수 요청 파라미터 누락
- `handleTypeMismatch` : 파라미터 타입 불일치
- **⭐ `handleMethodArgumentNotValid` : `@Valid`로 DTO 검증 실패 시 발생**
- `handleBindException` : GET 파라미터 바인딩 실패
- `handleMissingPathVariable` : PathVariable 누락
- `handleServletRequestBindingException` : 헤더, 쿠키 바인딩 실패
- `handleExceptionInternal` : `ResponseEntity` 만들 때 내부적으로 사용됨


### `exception()`

위의 핸들러들에서 잡지 못하는 모든 에러들을 처리하는 핸들러 이다.
`NullPointerException`, `ArrayIndexOutOfBoundsException` 등 개발자가 예측하지 못한 런타임 에러들..
서버에러 `_INTERNAL_SERVER_ERROR (HTTP 500)` 상태를 기반으로 표준 응답(ResponseEntity)을 생성하여 반환한다. ⇒ `handleExceptionInternalFalse` 호출

### `onThrowException`

이 메서드는 개발자가 직접 던진 커스텀 예외를 처리하는 코드이다.
비지니스 로직에서 발생하는 예외를 잡아서 표준 응답 형식으로 바꿔주는 역할 !
예외 발생시 **ErrorReasonDTO → ApiResponse → ResponseEntity** 로 변환 ⇒ `handleExceptionInternal` 호출

### `handleExceptionInternal`

ExceptionAdvice 안에서 반복적으로 처리되는 “예외 → ApiResponse → ResponseEntity 변환” 과정을 한 곳에 모아 재사용하도록 하는 헬퍼 메소드 이다.

data 필드는 null로 설정

👉 **핸들러(`onThrowException`)는 언제!! 예외를 처리할지 정함**

👉 **헬퍼(`handleExceptionInternal`)는 어떻게!! 응답을 만들지 정함**

### `handleExceptionInternalFalse`

`exception()` 메서드에서 호출하는 메서드로 일반적인 예외가 발생했을때 일관된 형태(`ApiResponse`)로 감싸서 ResponseEntity로 만들어주는 헬퍼 메서드이다.
여기서는 data 필드에 어디서 에러 메세지를 담는 errorpoint 를 담눈다.

### `handleExceptionInternalArgs`

MethodArgumentNotValidException (DTO 유효성 검사) 처리를 위한 표준 응답 ResponseEntity를 생성하는 헬퍼메소드 이다.

### `handleExceptionInternalConstraint`

ConstraintViolationException (파라미터 유효성 검사) 처리를 위한 표준 응답 ResponseEntity를 생성하는 헬퍼메소드이다.
</details>

<details>
  <summary>예외 처리 로직</summary>

<img width="374" height="284" alt="image" src="https://github.com/user-attachments/assets/a1b22a2f-9393-49bd-b173-d1f7e70b1cc7" />

- ApiResponse : 응답 형식 통일 (성공, 실패에 대한 응답 포맷 정의)
- GeneralException :모든 비지니스 예외의 부모 클래스
- ErrorHandler : 개발자가 직접 던지는 커스텀 예외 클래스
    - GeneralException을 상속받아 errorstatus 만 넣으면 바로 사용할 수 있도록
- ExceptionAdvice : 전역 예외 처리기 - 모든 예외를 잡아서 ApiResponse로 변환

🚨 예외 발생 -> 
1. `throw new ErrorHandler(ErrorStatus.___)` 

2. `GeneralException`을 상속받은 `ErrorHandler` 생성 

3. `ExceptionAdvice (@RestControllerAdvice)`에서 잡힘 

4. `handleExceptionInternal( )` 호출

5. `ApiResponse.onFailure( )` 로 통일된 실패 응답 생성

6. `ResponseEntity(ApiResponse)` 로 클라이언트에게 JSON 반환
</details>

<details>
  <summary>WebRequest</summary>

`ExceptionAdvice` 코드에서 `WebRequest`가 계속 보이길래 `HttpServletRequest`을 안쓰고 왜 이걸 쓰는지 궁금해서 찾아봤다. WebRequst는 SpringMVC에서 HTTP 요청 정보를 추상화한 인터페이스이다. 

`HttpServletRequest` 는 java servlet 에서 제공하는 인터페이스이고, 이 `WebRequest` 은 Spring Framework에서 제공하는 인터페이스이다. `HttpServletRequest` 보다 높은 수준의 추상화를 제공하고, spring mvc를 사용할때 spring의 다양한 기능과 통합할 수 있는 장점이 있다고 한다.

컨트롤러단에서는 `HttpServletRequest` 를 자주 사용하고, 예외 처리나 핸들러에서는 `WebRequest` 를 사용하는 것이 더 일반적이고 범용성이 높다고 함.>!>>!

비교 항목 | HttpServletRequest | WebRequest
-- | -- | --
속한 패키지 | javax.servlet.http (서블릿 전용) | org.springframework.web.context.request (Spring 공용)
의존성 | 서블릿 환경 필수 | 서블릿/Reactive 모두 지원
용도 | 요청 헤더, 바디, 세션, URI 등 세밀 제어 | 스프링 내 요청 컨텍스트 접근용
주 사용처 | 컨트롤러, 필터, 서블릿 | 예외 처리, 인터셉터, 스프링 내부 컴포넌트


<!-- notionvc: 8555d1cf-6117-483e-bfaa-f0518e6689be -->
</details>

<details>
  <summary>@RestControllerAdvice</summary>

> @RestControllerAdvice는 프로젝트 전체의 Controller에서 발생하는 예외(Exception) 를 한 곳에서 **통합적으로 처리**하기 위한 Spring의 **전역 예외 처리 기능**
<img width="400" height="324" alt="image" src="https://github.com/user-attachments/assets/e3ac1907-806a-4614-ba00-c912c112dd96" />

여기서 볼 수 있듯이 RestControllerAdvice는 ControllerAdvice와 ResponseBody를 합친 것이다. 전역 예외를 처리하되, 그 결과를 json으로 변환할 수 있도록 한다.

1. 컨트롤러나 서비스 계층에서 예외 발생
2. 스프링이 컨트롤러로 예외를 전달하려 함
3. `@RestControllerAdvice`가 등록되어 있다면, 스프링이 이 예외를 대신 처리할 수 있는 핸들러가 있는지 찾음
4. 해당 예외를 처리하는 `@ExceptionHandler` 메서드 실행
5. 결과를 `ResponseEntity` 형태(JSON 응답)로 클라이언트에게 반환

### 장점

1. **전역 예외 처리 - 한곳에서 모든 예외를 처리 ⇒ 코드 중복 제거**
    
    모든 컨트롤러에서 발생한 예외를 하나의 클래스에서 일괄처리할 수 있따. 이로서, 컨트롤러마다 try-catch문을 반복해서 작성할 필요가 없고, 예외나 로깅/응답 형식 통일이 가능하다. 따라서 유지보수가 쉽다는 장점이 있다. 모든 컨트롤러마다 예외 처리 코드를 적어야한다면......끔찍....
    
2. **응답 형식 통일 - ApiResponse 구조로 일관된 에러 응답 제공**
    
    모든 오류응답이 같은 json 형태로 제공된다. 이건 프론트엔드와의 협업에서도 굉장히 중요한 부분이기에 꼭 필요하다. 만약 응답 형식이 통일되지 않으면 컨트롤러마다 구조가 달라져버리기때문에 api 명세 유지가 어렵고, 프론트엔드에서 일관된 처리가 불가능하다.
    
3. **예외 종류별 세밀한 분기 처리 가능**
    - `GeneralException` → 비즈니스 예외
    - `ConstraintViolationException` → 요청 파라미터 유효성 실패
    - `MethodArgumentNotValidException` → @Valid DTO 검증 실패
    - `Exception` → 그 외 모든 예외
</details>

<details>
  <summary>시니어 미션 - 500 에러 발생 시 알림 전송 기능 구현 (디스코드)</summary>

<img width="400" height="522" alt="image" src="https://github.com/user-attachments/assets/dbd2bcd7-22b7-45d0-bad5-84053269f267" />

일단 결과 사진만 첨부할게요...

</details>
## 📌 PR 포인트
<!-- 이 부분 좀 주목해서 봐주세요! -->
- 

## ✅ 체크리스트
- [ ] Reviewer에 파트장을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 🤔 질문 & 고민
<!-- 다른 스터디원들에게 궁금한 점이 있다면 작성해주세요 -->